### PR TITLE
Add filtering controls for team stats scope

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -2,16 +2,25 @@ import { useState } from "react";
 
 import FixturesList from "./components/FixturesList";
 import RecordChart from "./components/RecordChart";
+import TeamFilters from "./components/TeamFilters";
 import TeamSearchForm, { type TeamSearchFormValues } from "./components/TeamSearchForm";
 import TeamSummary from "./components/TeamSummary";
 import { useTeamInsights } from "./hooks/useTeamInsights";
+import { DEFAULT_TEAM_INSIGHTS_FILTERS, type TeamInsightsFilters } from "./lib/apiFootball";
 
 const App: React.FC = () => {
+  const createDefaultFilters = () => ({ ...DEFAULT_TEAM_INSIGHTS_FILTERS });
   const [teamName, setTeamName] = useState<string | null>(null);
-  const { data, isLoading, isError, error, isFetching } = useTeamInsights(teamName);
+  const [filters, setFilters] = useState<TeamInsightsFilters>(createDefaultFilters);
+  const { data, isLoading, isError, error, isFetching } = useTeamInsights(teamName, filters);
 
   const handleSubmit = ({ teamName: submittedTeam }: TeamSearchFormValues) => {
     setTeamName(submittedTeam.trim());
+    setFilters(createDefaultFilters());
+  };
+
+  const handleFiltersChange = (nextFilters: TeamInsightsFilters) => {
+    setFilters(nextFilters);
   };
 
   return (
@@ -28,6 +37,15 @@ const App: React.FC = () => {
         </header>
 
         <TeamSearchForm isLoading={isLoading || isFetching} onSubmit={handleSubmit} initialTeam={teamName ?? undefined} />
+
+        {teamName ? (
+          <TeamFilters
+            availableSeasons={data?.availableSeasons ?? []}
+            filters={filters}
+            onChange={handleFiltersChange}
+            isLoading={isLoading || isFetching}
+          />
+        ) : null}
 
         {isError ? (
           <div className="rounded-2xl border border-rose-500/40 bg-rose-500/10 p-4 text-sm text-rose-200">

--- a/src/components/TeamFilters.tsx
+++ b/src/components/TeamFilters.tsx
@@ -1,0 +1,113 @@
+import { type ChangeEvent, useMemo } from "react";
+
+import type { TeamInsightsFilters } from "../lib/apiFootball";
+
+type TeamFiltersProps = {
+  availableSeasons: number[];
+  filters: TeamInsightsFilters;
+  onChange: (filters: TeamInsightsFilters) => void;
+  isLoading?: boolean;
+};
+
+const TeamFilters = ({
+  availableSeasons,
+  filters,
+  onChange,
+  isLoading = false,
+}: TeamFiltersProps) => {
+  const seasonOptions = useMemo(
+    () => [...availableSeasons].sort((a, b) => b - a),
+    [availableSeasons],
+  );
+
+  const handleModeChange = (mode: TeamInsightsFilters["mode"]) => {
+    if (mode === filters.mode) {
+      return;
+    }
+
+    if (mode === "season") {
+      const fallbackSeason = filters.season && seasonOptions.includes(filters.season)
+        ? filters.season
+        : seasonOptions[0] ?? null;
+      onChange({ mode, season: fallbackSeason ?? null });
+      return;
+    }
+
+    onChange({ mode, season: null });
+  };
+
+  const handleSeasonChange = (event: ChangeEvent<HTMLSelectElement>) => {
+    const value = event.target.value;
+    if (value === "") {
+      onChange({ mode: "season", season: null });
+      return;
+    }
+    const parsed = Number(value);
+    onChange({ mode: "season", season: Number.isFinite(parsed) ? parsed : null });
+  };
+
+  const isSeasonMode = filters.mode === "season";
+  const canSelectSeason = seasonOptions.length > 0;
+
+  return (
+    <section className="flex flex-col gap-4 rounded-2xl border border-slate-800 bg-slate-900/50 p-5">
+      <div className="flex flex-wrap items-center gap-2">
+        {(
+          [
+            { mode: "recent", label: "Последние матчи" },
+            { mode: "season", label: "По сезону" },
+            { mode: "all", label: "Все сезоны" },
+          ] satisfies { mode: TeamInsightsFilters["mode"]; label: string }[]
+        ).map(({ mode, label }) => {
+          const isActive = filters.mode === mode;
+          return (
+            <button
+              key={mode}
+              type="button"
+              onClick={() => handleModeChange(mode)}
+              disabled={isLoading}
+              className={`rounded-xl border px-4 py-2 text-sm font-semibold transition focus:outline-none focus:ring-2 focus:ring-primary-500/50 ${
+                isActive
+                  ? "border-primary-400 bg-primary-500/15 text-primary-200 shadow-inner shadow-primary-900/40"
+                  : "border-slate-700 text-slate-300 hover:border-primary-400/60 hover:text-primary-200"
+              } ${isLoading ? "cursor-not-allowed opacity-70" : ""}`}
+            >
+              {label}
+            </button>
+          );
+        })}
+      </div>
+      {isSeasonMode ? (
+        canSelectSeason ? (
+          <div className="flex flex-col gap-2">
+            <label className="text-xs font-semibold uppercase tracking-widest text-slate-400">
+              Выберите сезон
+            </label>
+            <select
+              className="w-full rounded-xl border border-slate-700 bg-slate-800/80 px-4 py-2 text-sm font-medium text-slate-100 outline-none transition focus:border-primary-400 focus:ring-2 focus:ring-primary-500/60"
+              value={filters.season ?? seasonOptions[0] ?? ""}
+              onChange={handleSeasonChange}
+              disabled={isLoading}
+            >
+              {seasonOptions.map((season) => (
+                <option key={season} value={season}>
+                  {season}
+                </option>
+              ))}
+            </select>
+          </div>
+        ) : (
+          <p className="text-sm text-slate-500">
+            Для этой команды не удалось получить список сезонов. Попробуйте другой режим фильтрации.
+          </p>
+        )
+      ) : null}
+      <p className="text-xs text-slate-500">
+        Если статистика отображается нулями, выберите другой сезон или включите режим «Все сезоны», чтобы
+        собрать данные за более длительный период.
+      </p>
+    </section>
+  );
+};
+
+export default TeamFilters;

--- a/src/components/TeamSummary.tsx
+++ b/src/components/TeamSummary.tsx
@@ -5,10 +5,19 @@ type TeamSummaryProps = {
 };
 
 const TeamSummary: React.FC<TeamSummaryProps> = ({ insights }) => {
-  const { team, venue, record } = insights;
+  const { team, venue, record, filters } = insights;
   const winRate = insights.fixtures.length
     ? Math.round((record.wins / insights.fixtures.length) * 100)
     : 0;
+  const filterLabel = (() => {
+    if (filters.mode === "all") {
+      return "Все доступные сезоны";
+    }
+    if (filters.mode === "season") {
+      return filters.season ? `Сезон ${filters.season}` : "Сезон недоступен";
+    }
+    return "Последние 10 матчей";
+  })();
 
   return (
     <section className="grid grid-cols-1 gap-6 rounded-3xl bg-gradient-to-br from-slate-900/90 via-slate-900/60 to-slate-900/30 p-6 shadow-2xl shadow-primary-900/30 md:grid-cols-[1.4fr_1fr]">
@@ -40,16 +49,28 @@ const TeamSummary: React.FC<TeamSummaryProps> = ({ insights }) => {
           </div>
         </div>
         <div className="rounded-2xl border border-slate-800 bg-slate-900/70 p-5">
-          <div className="flex items-center justify-between">
-            <div>
-              <p className="text-xs uppercase tracking-widest text-slate-400">Разница мячей</p>
-              <p className="mt-1 text-xl font-semibold text-white">
-                {record.goalsFor} : {record.goalsAgainst}
-              </p>
+          <div className="flex flex-col gap-4">
+            <div className="flex items-center justify-between">
+              <div>
+                <p className="text-xs uppercase tracking-widest text-slate-400">Разница мячей</p>
+                <p className="mt-1 text-xl font-semibold text-white">
+                  {record.goalsFor} : {record.goalsAgainst}
+                </p>
+              </div>
+              <div className="text-right">
+                <p className="text-xs uppercase tracking-widest text-slate-400">Winrate</p>
+                <p className="mt-1 text-xl font-semibold text-primary-300">{winRate}%</p>
+              </div>
             </div>
-            <div className="text-right">
-              <p className="text-xs uppercase tracking-widest text-slate-400">Winrate</p>
-              <p className="mt-1 text-xl font-semibold text-primary-300">{winRate}%</p>
+            <div className="border-t border-slate-800 pt-4">
+              <p className="text-xs uppercase tracking-widest text-slate-400">Диапазон данных</p>
+              <p className="mt-1 text-sm text-slate-200">{filterLabel}</p>
+              <p className="text-xs text-slate-500">
+                Матчей в выборке: {filters.matchesCount}
+                {filters.matchesCount === 0
+                  ? ". Попробуйте выбрать другой сезон или режим выборки."
+                  : ""}
+              </p>
             </div>
           </div>
         </div>

--- a/src/hooks/useTeamInsights.ts
+++ b/src/hooks/useTeamInsights.ts
@@ -1,15 +1,22 @@
 import { useQuery } from "@tanstack/react-query";
 
-import { fetchTeamInsights } from "../lib/apiFootball";
+import {
+  DEFAULT_TEAM_INSIGHTS_FILTERS,
+  fetchTeamInsights,
+  type TeamInsightsFilters,
+} from "../lib/apiFootball";
 
-export const useTeamInsights = (teamName: string | null) =>
+export const useTeamInsights = (
+  teamName: string | null,
+  filters: TeamInsightsFilters = DEFAULT_TEAM_INSIGHTS_FILTERS,
+) =>
   useQuery({
-    queryKey: ["team-insights", teamName],
+    queryKey: ["team-insights", teamName, filters],
     queryFn: () => {
       if (!teamName) {
         throw new Error("Не указано название команды");
       }
-      return fetchTeamInsights(teamName);
+      return fetchTeamInsights(teamName, filters);
     },
     enabled: Boolean(teamName),
     staleTime: 1000 * 60 * 5,


### PR DESCRIPTION
## Summary
- add reusable team filters component and allow selecting recent, seasonal, or all-season scopes
- extend API client and hook to request fixtures with the chosen scope and expose available seasons
- surface the applied data range in the team summary to explain empty statistics

## Testing
- npm run lint *(fails: pre-existing @typescript-eslint/no-explicit-any errors in types/node-shim.d.ts)*

------
https://chatgpt.com/codex/tasks/task_e_68e6b731cad083328525821cad4af219